### PR TITLE
 Add timeout for RPC connections #3 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MITNFA"
 doctest = false
 
 [dependencies]
-tonic = "0.10.2"
+tonic = "0.10"
 tonic-openssl = { version = "0.2" }
 hyper = "0.14"
 hyper-openssl = "0.9"
@@ -29,4 +29,4 @@ pretty_env_logger = "*"
 hex = "0.4.3"
 
 [build-dependencies]
-tonic-build = "0.10.2"
+tonic-build = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tonic_lnd"
 version = "0.5.0"
 authors = ["Martin Habovstiak <martin.habovstiak@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "An async library implementing LND RPC via tonic and prost"
 homepage = "https://github.com/Kixunil/tonic_lnd"
 repository = "https://github.com/Kixunil/tonic_lnd"
@@ -15,11 +15,12 @@ license = "MITNFA"
 doctest = false
 
 [dependencies]
-tonic = "0.7"
+tonic = "0.10.2"
 tonic-openssl = { version = "0.2" }
 hyper = "0.14"
 hyper-openssl = "0.9"
-prost = "0.10"
+prost = "0.12"
+prost-types = "0.12"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 openssl = "0.10"
@@ -28,4 +29,4 @@ pretty_env_logger = "*"
 hex = "0.4.3"
 
 [build-dependencies]
-tonic-build = "0.7"
+tonic-build = "0.10.2"

--- a/examples/getinfo.rs
+++ b/examples/getinfo.rs
@@ -4,6 +4,8 @@
 // This program accepts three arguments: address, cert file, macaroon file
 // The address must start with `https://`!
 
+use std::time::Duration;
+
 #[tokio::main]
 async fn main() {
     let mut args = std::env::args_os();
@@ -32,7 +34,7 @@ async fn main() {
         .expect("macaroon_file is not UTF-8");
 
     // Connecting to LND requires only host, port, cert file, macaroon file
-    let mut client = tonic_lnd::connect(host, port, cert_file, macaroon_file)
+    let mut client = tonic_lnd::connect(Some(Duration::new(20_u64, 0_u32)), host, port, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
 

--- a/examples/getinfo.rs
+++ b/examples/getinfo.rs
@@ -34,7 +34,7 @@ async fn main() {
         .expect("macaroon_file is not UTF-8");
 
     // Connecting to LND requires only host, port, cert file, macaroon file
-    let mut client = tonic_lnd::connect(Some(Duration::new(20_u64, 0_u32)), host, port, cert_file, macaroon_file)
+    let mut client = tonic_lnd::connect(host, port, cert_file, macaroon_file, Some(Duration::new(20_u64, 0_u32)))
         .await
         .expect("failed to connect");
 

--- a/examples/subscribe_invoices.rs
+++ b/examples/subscribe_invoices.rs
@@ -2,6 +2,8 @@
 // The program accepts three arguments: address, cert file, macaroon file
 // The address must start with `https://`!
 
+use std::time::Duration;
+
 #[tokio::main]
 async fn main() {
     let mut args = std::env::args_os();
@@ -30,7 +32,7 @@ async fn main() {
         .expect("macaroon_file is not UTF-8");
 
     // Connecting to LND requires only address, cert file, and macaroon file
-    let mut client = tonic_lnd::connect(host, port, cert_file, macaroon_file)
+    let mut client = tonic_lnd::connect(Some(Duration::new(20_u64, 0_u32)), host, port, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
 
@@ -49,9 +51,9 @@ async fn main() {
         .await
         .expect("Failed to receive invoices")
     {
-        if let Some(state) = tonic_lnd::lnrpc::invoice::InvoiceState::from_i32(invoice.state) {
+        if let Some(state) = TryInto::<i32>::try_into(invoice.state).ok() {
             // If this invoice was Settled we can do something with it
-            if state == tonic_lnd::lnrpc::invoice::InvoiceState::Settled {
+            if state == tonic_lnd::lnrpc::invoice::InvoiceState::Settled.into() {
                 println!("{:?}", invoice);
             }
         }

--- a/examples/subscribe_invoices.rs
+++ b/examples/subscribe_invoices.rs
@@ -32,7 +32,7 @@ async fn main() {
         .expect("macaroon_file is not UTF-8");
 
     // Connecting to LND requires only address, cert file, and macaroon file
-    let mut client = tonic_lnd::connect(Some(Duration::new(20_u64, 0_u32)), host, port, cert_file, macaroon_file)
+    let mut client = tonic_lnd::connect(host, port, cert_file, macaroon_file, Some(Duration::new(20_u64, 0_u32)))
         .await
         .expect("failed to connect");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@ use openssl::{
     x509::X509,
 };
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::time::Duration;
 use std::{error::Error, task::Poll};
 use tonic::body::BoxBody;
 use tonic::codegen::InterceptedService;
@@ -166,6 +168,7 @@ async fn load_macaroon(
 }
 
 pub async fn connect(
+    timeout: Option<Duration>,
     lnd_host: String,
     lnd_port: u32,
     lnd_tls_cert_path: String,
@@ -175,7 +178,7 @@ pub async fn connect(
 
     let pem = tokio::fs::read(lnd_tls_cert_path).await.ok();
     let uri = lnd_address.parse::<Uri>().unwrap();
-    let channel = SslChannel::new(pem, uri).await?;
+    let channel = SslChannel::new(pem, uri, timeout).await?;
 
     let macaroon = load_macaroon(lnd_macaroon_path).await.unwrap();
     let interceptor = MacaroonInterceptor { macaroon };
@@ -195,6 +198,7 @@ pub async fn connect(
 }
 
 pub async fn connect_string(
+    timeout: Option<Duration>,
     lnd_host: String,
     lnd_port: u32,
     lnd_tls_cert_contents: Vec<u8>,
@@ -203,7 +207,7 @@ pub async fn connect_string(
     let lnd_address = format!("https://{}:{}", lnd_host, lnd_port).to_string();
 
     let uri = lnd_address.parse::<Uri>().unwrap();
-    let channel = SslChannel::new(Some(lnd_tls_cert_contents), uri).await?;
+    let channel = SslChannel::new(Some(lnd_tls_cert_contents), uri, timeout).await?;
 
     let interceptor = MacaroonInterceptor { macaroon };
 
@@ -234,9 +238,16 @@ enum SslClient {
 }
 
 impl SslChannel {
-    pub async fn new(certificate: Option<Vec<u8>>, uri: Uri) -> Result<Self, Box<dyn Error>> {
+    pub async fn new(
+        certificate: Option<Vec<u8>>,
+        uri: Uri,
+        timeout: Option<Duration>,
+    ) -> Result<Self, Box<dyn Error>> {
         let mut http = HttpConnector::new();
+
+        http.set_connect_timeout(timeout);
         http.enforce_http(false);
+
         let client = match certificate {
             None => SslClient::ClearText(Client::builder().http2_only(true).build(http)),
             Some(pem) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,11 +168,11 @@ async fn load_macaroon(
 }
 
 pub async fn connect(
-    timeout: Option<Duration>,
     lnd_host: String,
     lnd_port: u32,
     lnd_tls_cert_path: String,
     lnd_macaroon_path: String,
+    timeout: Option<Duration>,
 ) -> Result<LndClient, Box<dyn std::error::Error>> {
     let lnd_address = format!("https://{}:{}", lnd_host, lnd_port).to_string();
 
@@ -198,11 +198,11 @@ pub async fn connect(
 }
 
 pub async fn connect_string(
-    timeout: Option<Duration>,
     lnd_host: String,
     lnd_port: u32,
     lnd_tls_cert_contents: Vec<u8>,
     macaroon: String,
+    timeout: Option<Duration>,
 ) -> Result<LndClient, Box<dyn std::error::Error>> {
     let lnd_address = format!("https://{}:{}", lnd_host, lnd_port).to_string();
 


### PR DESCRIPTION
updating to include a timeout option with the http connection, also updating tonic dependency to include this fix (adds the timeout to the connection):

https://github.com/hyperium/tonic/blame/b3fca19104bf001d3a3dac74221b7c9bede13cf1/tonic/src/transport/service/discover.rs#L39
