### PR TITLE
feat: add rustls system cert method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ hyper = { version = "0.14.27", features = ["client"], default-features = false }
 prost = "0.12.0"
 rustls = { version = "0.21.0", features = ["dangerous_configuration"], default-features = false }
 rustls-pemfile = "1.0.0"
+rustls-platform-verifier = { version = "0.1.0", optional = true }
 hyper-rustls = { version = "0.24.1", features = ["acceptor", "http2", "tls12"], default-features = false }
 tonic = { version = "0.10.0", features = ["transport", "tls"] }
 tokio = { version = "1.32.0", features = ["fs"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,17 @@ pub async fn connect_from_memory(
     do_connect(address, tls_config, macaroon).await
 }
 
+#[cfg(feature = "rustls-platform-verifier")]
+pub async fn connect_from_memory_with_system_certs(
+    address: impl ToString,
+    macaroon: impl ToString,
+) -> Result<Client, ConnectError> {
+    let address = address.to_string();
+    let macaroon = macaroon.to_string();
+    let config = rustls_platform_verifier::tls_config();
+    do_connect(address, config, macaroon).await
+}
+
 async fn do_connect(
     address: String,
     tls_config: ClientConfig,


### PR DESCRIPTION
it is desired in many instances (Voltage) to use the system certs instead of having to pass the tls
certs to use when interacting with the lnd node. this adds a method to initialize a connection using
the system certs.