### PR TITLE
feat: expose LND chainrpc clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,9 +368,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -1472,6 +1472,6 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ versionrpc = []
 routerrpc = ["lightningrpc"]
 invoicesrpc = ["lightningrpc"]
 staterpc = ["lightningrpc"]
-lightning = ["lightningrpc", "walletrpc", "peersrpc", "versionrpc", "routerrpc", "invoicesrpc", "staterpc"]
+chainrpc = []
+lightning = ["lightningrpc", "walletrpc", "peersrpc", "versionrpc", "routerrpc", "invoicesrpc", "staterpc", "chainrpc"]
 taprpc = []
 assetwalletrpc = ["taprpc"]
 mintrpc = ["taprpc"]
@@ -47,14 +48,14 @@ default = ["lightning", "ring", "tls"]
 
 [dependencies]
 hex = "0.4.3"
-http = "1.4.0"
-prost = "0.14.3"
-tonic-prost = "0.14.5"
+http = "1.4.2"
+prost = "0.14.4"
+tonic-prost = "0.14.6"
 thiserror = "2.0.18"
 tokio = { version = "1.50.0", features = ["fs"] }
 tokio-stream = { version = "0.1", features = ["net"], optional = true}
 tonic = { version = "0.14.6", features = ["transport"] }
-zeroize = "1.8.2"
+zeroize = "1.9.0"
 
 [build-dependencies]
 tonic-prost-build = "0.14.6"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rust implementation of LND RPC client using async gRPC library `tonic`.
 **Warning: this crate is in early development and may have unknown problems!
 Review it before using with mainnet funds!**
 
-This crate supports the following LND RPC APIs (from LND [v0.19.1-beta](https://github.com/lightningnetwork/lnd/tree/v0.19.1-beta)):
+This crate supports the following LND RPC APIs (from LND [v0.21.1-beta](https://github.com/lightningnetwork/lnd/tree/v0.21.1-beta)):
 - [Lightning](https://lightning.engineering/api-docs/category/lightning-service)
 - [WalletKit](https://lightning.engineering/api-docs/category/walletkit-service)
 - [Signer](https://lightning.engineering/api-docs/category/signer-service)
@@ -18,6 +18,8 @@ This crate supports the following LND RPC APIs (from LND [v0.19.1-beta](https://
 - [Router](https://lightning.engineering/api-docs/category/router-service)
 - [Invoices](https://lightning.engineering/api-docs/category/invoices-service)
 - [State](https://lightning.engineering/api-docs/category/state-service)
+- [ChainNotifier](https://lightning.engineering/api-docs/category/chainnotifier-service)
+- [ChainKit](https://lightning.engineering/api-docs/category/chainkit-service)
 - [Versioner](https://lightning.engineering/api-docs/category/versioner-service)
 
 This crate also supports [Taproot Assets](https://github.com/lightninglabs/taproot-assets) RPC APIs (from Taproot Assets [v0.6.1](https://github.com/lightninglabs/taproot-assets/tree/v0.6.1)):
@@ -44,6 +46,7 @@ Each RPC API is behind a Cargo feature flag. All features are enabled by default
 - `routerrpc` (Router)
 - `invoicesrpc` (Invoices)
 - `staterpc` (State)
+- `chainrpc` (ChainNotifier and ChainKit)
 - `versionrpc` (Versioner)
 - `lightning` (enables all LND RPCs)
 
@@ -95,6 +98,12 @@ To use Taproot Assets features:
 voltage-tonic-lnd = { version = "0.1", default-features = false, features = ["lightningrpc", "taprootassets", "ring", "tls-native-roots"] }
 ```
 
+To use chain confirmation APIs without the full default feature set:
+
+```toml
+voltage-tonic-lnd = { version = "0.1", default-features = false, features = ["chainrpc", "ring", "tls-native-roots"] }
+```
+
 If you need to override the proto files, set the `LND_REPO_DIR` environment variable to a directory with a cloned [`lnd`](https://github.com/lightningnetwork/lnd.git) repo during build. For Taproot Assets proto files, set the `TAPROOT_ASSETS_REPO_DIR` environment variable to a directory with a cloned [`taproot-assets`](https://github.com/lightninglabs/taproot-assets.git) repo.
 
 ### Example: Connect and Get Info
@@ -117,7 +126,34 @@ async fn main() -> voltage_tonic_lnd::Result<()> {
 }
 ```
 
-See more [examples in the repo](https://github.com/voltagecloud/tonic-lnd/tree/master/examples) for advanced usage (router, invoices, payments, intercept HTLCs, etc).
+See more [examples in the repo](https://github.com/voltagecloud/tonic_lnd/tree/master/examples) for advanced usage (router, invoices, payments, intercept HTLCs, etc).
+
+### Example: Chain Confirmation APIs
+
+```rust
+let mut client = voltage_tonic_lnd::Client::builder()
+    .address("https://localhost:10009")
+    .macaroon_contents(hex_macaroon_string)
+    .cert_contents(pem_cert_string)
+    .build()
+    .await?;
+
+let best_block = client
+    .chain_kit()
+    .get_best_block(voltage_tonic_lnd::chainrpc::GetBestBlockRequest {})
+    .await?;
+
+let confirmation_stream = client
+    .chain_notifier()
+    .register_confirmations_ntfn(voltage_tonic_lnd::chainrpc::ConfRequest {
+        txid,
+        script,
+        num_confs: 1,
+        height_hint: best_block.into_inner().block_height as u32,
+        include_block: false,
+    })
+    .await?;
+```
 
 ### Alternative: In-Memory Credentials
 

--- a/build.rs
+++ b/build.rs
@@ -11,6 +11,8 @@ fn main() -> std::io::Result<()> {
     println!("cargo:rerun-if-changed={}", proto_file.display());
 
     let protos = [
+        "chainrpc/chainkit.proto",
+        "chainrpc/chainnotifier.proto",
         "invoicesrpc/invoices.proto",
         "lightning.proto",
         "peersrpc/peers.proto",

--- a/src/client.rs
+++ b/src/client.rs
@@ -43,6 +43,14 @@ pub type InvoicesClient = invoicesrpc::invoices_client::InvoicesClient<Service>;
 #[cfg(feature = "staterpc")]
 pub type StateClient = lnrpc::state_client::StateClient<Service>;
 
+/// Convenience type alias for chain notifier client.
+#[cfg(feature = "chainrpc")]
+pub type ChainNotifierClient = chainrpc::chain_notifier_client::ChainNotifierClient<Service>;
+
+/// Convenience type alias for chain kit client.
+#[cfg(feature = "chainrpc")]
+pub type ChainKitClient = chainrpc::chain_kit_client::ChainKitClient<Service>;
+
 /// Convenience type alias for taproot assets client.
 #[cfg(feature = "taprpc")]
 pub type TaprootAssetsClient = taprpc::taproot_assets_client::TaprootAssetsClient<Service>;
@@ -311,6 +319,10 @@ pub struct Client {
     invoices: InvoicesClient,
     #[cfg(feature = "staterpc")]
     state: StateClient,
+    #[cfg(feature = "chainrpc")]
+    chain_notifier: ChainNotifierClient,
+    #[cfg(feature = "chainrpc")]
+    chain_kit: ChainKitClient,
     #[cfg(feature = "taprpc")]
     taproot_assets: TaprootAssetsClient,
     #[cfg(feature = "assetwalletrpc")]
@@ -429,6 +441,30 @@ impl Client {
     #[cfg(feature = "staterpc")]
     pub fn state_read_only(self) -> StateClient {
         self.state
+    }
+
+    /// Returns the chain notifier client.
+    #[cfg(feature = "chainrpc")]
+    pub fn chain_notifier(&mut self) -> &mut ChainNotifierClient {
+        &mut self.chain_notifier
+    }
+
+    /// Returns a read-only chain notifier client.
+    #[cfg(feature = "chainrpc")]
+    pub fn chain_notifier_read_only(self) -> ChainNotifierClient {
+        self.chain_notifier
+    }
+
+    /// Returns the chain kit client.
+    #[cfg(feature = "chainrpc")]
+    pub fn chain_kit(&mut self) -> &mut ChainKitClient {
+        &mut self.chain_kit
+    }
+
+    /// Returns a read-only chain kit client.
+    #[cfg(feature = "chainrpc")]
+    pub fn chain_kit_read_only(self) -> ChainKitClient {
+        self.chain_kit
     }
 
     /// Returns the taproot assets client.
@@ -690,6 +726,16 @@ async fn do_connect(
         ),
         #[cfg(feature = "staterpc")]
         state: lnrpc::state_client::StateClient::with_origin(channel.clone(), uri.clone()),
+        #[cfg(feature = "chainrpc")]
+        chain_notifier: chainrpc::chain_notifier_client::ChainNotifierClient::with_origin(
+            channel.clone(),
+            uri.clone(),
+        ),
+        #[cfg(feature = "chainrpc")]
+        chain_kit: chainrpc::chain_kit_client::ChainKitClient::with_origin(
+            channel.clone(),
+            uri.clone(),
+        ),
         #[cfg(feature = "taprpc")]
         taproot_assets: taprpc::taproot_assets_client::TaprootAssetsClient::with_origin(
             channel.clone(),

--- a/src/protos.rs
+++ b/src/protos.rs
@@ -37,6 +37,11 @@ pub mod invoicesrpc {
     tonic::include_proto!("invoicesrpc");
 }
 
+#[cfg(feature = "chainrpc")]
+pub mod chainrpc {
+    tonic::include_proto!("chainrpc");
+}
+
 #[cfg(feature = "taprpc")]
 pub mod taprpc {
     tonic::include_proto!("taprpc");

--- a/vendor/chainrpc/chainkit.proto
+++ b/vendor/chainrpc/chainkit.proto
@@ -1,0 +1,74 @@
+syntax = "proto3";
+
+package chainrpc;
+
+option go_package = "github.com/lightningnetwork/lnd/lnrpc/chainrpc";
+
+// ChainKit is a service that can be used to get information from the
+// chain backend.
+service ChainKit {
+    /* lncli: `chain getblock`
+    GetBlock returns a block given the corresponding block hash.
+    */
+    rpc GetBlock (GetBlockRequest) returns (GetBlockResponse);
+
+    /* lncli: `chain getblockheader`
+    GetBlockHeader returns a block header with a particular block hash.
+    */
+    rpc GetBlockHeader (GetBlockHeaderRequest) returns (GetBlockHeaderResponse);
+
+    /* lncli: `chain getbestblock`
+    GetBestBlock returns the block hash and current height from the valid
+    most-work chain.
+    */
+    rpc GetBestBlock (GetBestBlockRequest) returns (GetBestBlockResponse);
+
+    /* lncli: `chain getblockhash`
+    GetBlockHash returns the hash of the block in the best blockchain
+    at the given height.
+    */
+    rpc GetBlockHash (GetBlockHashRequest) returns (GetBlockHashResponse);
+}
+
+message GetBlockRequest {
+    // The hash of the requested block.
+    bytes block_hash = 1;
+}
+
+// TODO(ffranr): The neutrino GetBlock response includes many
+// additional helpful fields. Consider adding them here also.
+message GetBlockResponse {
+    // The raw bytes of the requested block.
+    bytes raw_block = 1;
+}
+
+message GetBlockHeaderRequest {
+    // The hash of the block with the requested header.
+    bytes block_hash = 1;
+}
+
+message GetBlockHeaderResponse {
+    // The header of the block with the requested hash.
+    bytes raw_block_header = 1;
+}
+
+message GetBestBlockRequest {
+}
+
+message GetBestBlockResponse {
+    // The hash of the best block.
+    bytes block_hash = 1;
+
+    // The height of the best block.
+    int32 block_height = 2;
+}
+
+message GetBlockHashRequest {
+    // Block height of the target best chain block.
+    int64 block_height = 1;
+}
+
+message GetBlockHashResponse {
+    // The hash of the best block at the specified height.
+    bytes block_hash = 1;
+}

--- a/vendor/chainrpc/chainnotifier.proto
+++ b/vendor/chainrpc/chainnotifier.proto
@@ -1,0 +1,200 @@
+syntax = "proto3";
+
+package chainrpc;
+
+option go_package = "github.com/lightningnetwork/lnd/lnrpc/chainrpc";
+
+// ChainNotifier is a service that can be used to get information about the
+// chain backend by registering notifiers for chain events.
+service ChainNotifier {
+    /*
+    RegisterConfirmationsNtfn is a synchronous response-streaming RPC that
+    registers an intent for a client to be notified once a confirmation request
+    has reached its required number of confirmations on-chain.
+
+    A confirmation request must have a valid output script. It is also possible
+    to give a transaction ID. If the transaction ID is not set, a notification
+    is sent once the output script confirms. If the transaction ID is also set,
+    a notification is sent once the output script confirms in the given
+    transaction.
+    */
+    rpc RegisterConfirmationsNtfn (ConfRequest) returns (stream ConfEvent);
+
+    /*
+    RegisterSpendNtfn is a synchronous response-streaming RPC that registers an
+    intent for a client to be notification once a spend request has been spent
+    by a transaction that has confirmed on-chain.
+
+    A client can specify whether the spend request should be for a particular
+    outpoint  or for an output script by specifying a zero outpoint.
+    */
+    rpc RegisterSpendNtfn (SpendRequest) returns (stream SpendEvent);
+
+    /*
+    RegisterBlockEpochNtfn is a synchronous response-streaming RPC that
+    registers an intent for a client to be notified of blocks in the chain. The
+    stream will return a hash and height tuple of a block for each new/stale
+    block in the chain. It is the client's responsibility to determine whether
+    the tuple returned is for a new or stale block in the chain.
+
+    A client can also request a historical backlog of blocks from a particular
+    point. This allows clients to be idempotent by ensuring that they do not
+    missing processing a single block within the chain.
+    */
+    rpc RegisterBlockEpochNtfn (BlockEpoch) returns (stream BlockEpoch);
+}
+
+message ConfRequest {
+    /*
+    The transaction hash for which we should request a confirmation notification
+    for. If set to a hash of all zeros, then the confirmation notification will
+    be requested for the script instead.
+    */
+    bytes txid = 1;
+
+    /*
+    An output script within a transaction with the hash above which will be used
+    by light clients to match block filters. If the transaction hash is set to a
+    hash of all zeros, then a confirmation notification will be requested for
+    this script instead.
+    */
+    bytes script = 2;
+
+    /*
+    The number of desired confirmations the transaction/output script should
+    reach before dispatching a confirmation notification.
+    */
+    uint32 num_confs = 3;
+
+    /*
+    The earliest height in the chain for which the transaction/output script
+    could have been included in a block. This should in most cases be set to the
+    broadcast height of the transaction/output script.
+    */
+    uint32 height_hint = 4;
+
+    /*
+    If true, then the block that mines the specified txid/script will be
+    included in eventual the notification event.
+    */
+    bool include_block = 5;
+}
+
+message ConfDetails {
+    // The raw bytes of the confirmed transaction.
+    bytes raw_tx = 1;
+
+    // The hash of the block in which the confirmed transaction was included in.
+    bytes block_hash = 2;
+
+    // The height of the block in which the confirmed transaction was included
+    // in.
+    uint32 block_height = 3;
+
+    // The index of the confirmed transaction within the block.
+    uint32 tx_index = 4;
+
+    /*
+    The raw bytes of the block that mined the transaction. Only included if
+    include_block was set in the request.
+    */
+    bytes raw_block = 5;
+}
+
+message Reorg {
+    // TODO(wilmer): need to know how the client will use this first.
+}
+
+message ConfEvent {
+    oneof event {
+        /*
+        An event that includes the confirmation details of the request
+        (txid/ouput script).
+        */
+        ConfDetails conf = 1;
+
+        /*
+        An event send when the transaction of the request is reorged out of the
+        chain.
+        */
+        Reorg reorg = 2;
+    }
+}
+
+message Outpoint {
+    // The hash of the transaction.
+    bytes hash = 1;
+
+    // The index of the output within the transaction.
+    uint32 index = 2;
+}
+
+message SpendRequest {
+    /*
+    The outpoint for which we should request a spend notification for. If set to
+    a zero outpoint, then the spend notification will be requested for the
+    script instead. A zero or nil outpoint is not supported for Taproot spends
+    because the output script cannot reliably be computed from the witness alone
+    and the spent output script is not always available in the rescan context.
+    So an outpoint must _always_ be specified when registering a spend
+    notification for a Taproot output.
+    */
+    Outpoint outpoint = 1;
+
+    /*
+    The output script for the outpoint above. This will be used by light clients
+    to match block filters. If the outpoint is set to a zero outpoint, then a
+    spend notification will be requested for this script instead.
+    */
+    bytes script = 2;
+
+    /*
+    The earliest height in the chain for which the outpoint/output script could
+    have been spent. This should in most cases be set to the broadcast height of
+    the outpoint/output script.
+    */
+    uint32 height_hint = 3;
+
+    // TODO(wilmer): extend to support num confs on spending tx.
+}
+
+message SpendDetails {
+    // The outpoint was that spent.
+    Outpoint spending_outpoint = 1;
+
+    // The raw bytes of the spending transaction.
+    bytes raw_spending_tx = 2;
+
+    // The hash of the spending transaction.
+    bytes spending_tx_hash = 3;
+
+    // The input of the spending transaction that fulfilled the spend request.
+    uint32 spending_input_index = 4;
+
+    // The height at which the spending transaction was included in a block.
+    uint32 spending_height = 5;
+}
+
+message SpendEvent {
+    oneof event {
+        /*
+        An event that includes the details of the spending transaction of the
+        request (outpoint/output script).
+        */
+        SpendDetails spend = 1;
+
+        /*
+        An event sent when the spending transaction of the request was
+        reorged out of the chain.
+        */
+        Reorg reorg = 2;
+    }
+}
+
+message BlockEpoch {
+    // The hash of the block.
+    bytes hash = 1;
+
+    // The height of the block.
+    uint32 height = 2;
+}

--- a/vendor/lightning.proto
+++ b/vendor/lightning.proto
@@ -262,47 +262,6 @@ service Lightning {
     */
     rpc AbandonChannel (AbandonChannelRequest) returns (AbandonChannelResponse);
 
-    /* lncli: `sendpayment`
-    Deprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a
-    bi-directional streaming RPC for sending payments through the Lightning
-    Network. A single RPC invocation creates a persistent bi-directional
-    stream allowing clients to rapidly send payments through the Lightning
-    Network with a single persistent connection.
-    */
-    rpc SendPayment (stream SendRequest) returns (stream SendResponse) {
-        option deprecated = true;
-    }
-
-    /*
-    Deprecated, use routerrpc.SendPaymentV2. SendPaymentSync is the synchronous
-    non-streaming version of SendPayment. This RPC is intended to be consumed by
-    clients of the REST proxy. Additionally, this RPC expects the destination's
-    public key and the payment hash (if any) to be encoded as hex strings.
-    */
-    rpc SendPaymentSync (SendRequest) returns (SendResponse) {
-        option deprecated = true;
-    }
-
-    /* lncli: `sendtoroute`
-    Deprecated, use routerrpc.SendToRouteV2. SendToRoute is a bi-directional
-    streaming RPC for sending payment through the Lightning Network. This
-    method differs from SendPayment in that it allows users to specify a full
-    route manually. This can be used for things like rebalancing, and atomic
-    swaps.
-    */
-    rpc SendToRoute (stream SendToRouteRequest) returns (stream SendResponse) {
-        option deprecated = true;
-    }
-
-    /*
-    Deprecated, use routerrpc.SendToRouteV2. SendToRouteSync is a synchronous
-    version of SendToRoute. It Will block until the payment either fails or
-    succeeds.
-    */
-    rpc SendToRouteSync (SendToRouteRequest) returns (SendResponse) {
-        option deprecated = true;
-    }
-
     /* lncli: `addinvoice`
     AddInvoice attempts to add a new invoice to the invoice database. Any
     duplicated invoices are rejected, therefore all invoices *must* have a
@@ -340,6 +299,13 @@ service Lightning {
     the latest add/settle events.
     */
     rpc SubscribeInvoices (InvoiceSubscription) returns (stream Invoice);
+
+    /* lncli: `deletecanceledinvoice`
+    DeleteCanceledInvoice removes a canceled invoice from the database. If the
+    invoice is not in the canceled state, an error will be returned.
+    */
+    rpc DeleteCanceledInvoice (DelCanceledInvoiceReq)
+        returns (DelCanceledInvoiceResp);
 
     /* lncli: `decodepayreq`
     DecodePayReq takes an encoded payment request string and attempts to decode
@@ -548,9 +514,10 @@ service Lightning {
         returns (ListPermissionsResponse);
 
     /*
-    CheckMacaroonPermissions checks whether a request follows the constraints
-    imposed on the macaroon and that the macaroon is authorized to follow the
-    provided permissions.
+    CheckMacaroonPermissions checks whether the provided macaroon contains all
+    the provided permissions. If the macaroon is valid (e.g. all caveats are
+    satisfied), and all permissions provided in the request are met, then
+    this RPC returns true.
     */
     rpc CheckMacaroonPermissions (CheckMacPermRequest)
         returns (CheckMacPermResponse);
@@ -588,6 +555,18 @@ service Lightning {
     */
     rpc SubscribeCustomMessages (SubscribeCustomMessagesRequest)
         returns (stream CustomMessage);
+
+    /* lncli: `sendonion`
+    SendOnionMessage sends an onion message to a peer.
+    */
+    rpc SendOnionMessage (SendOnionMessageRequest)
+        returns (SendOnionMessageResponse);
+
+    /* lncli: `subscribeonion`
+    SubscribeOnionMessages subscribes to a stream of incoming onion messages.
+    */
+    rpc SubscribeOnionMessages (SubscribeOnionMessagesRequest)
+        returns (stream OnionMessageUpdate);
 
     /* lncli: `listaliases`
     ListAliases returns the set of all aliases that have ever existed with
@@ -634,7 +613,8 @@ message CustomMessage {
 }
 
 message SendCustomMessageRequest {
-    // Peer to send the message to
+    // Peer to which the message will be sent. Represented as a byte-encoded
+    // public key
     bytes peer = 1;
 
     // Message type. This value needs to be in the custom range (>= 32768).
@@ -649,6 +629,67 @@ message SendCustomMessageRequest {
 
 message SendCustomMessageResponse {
     // The status of the send operation.
+    string status = 1;
+}
+
+message SubscribeOnionMessagesRequest {
+}
+
+message OnionMessageUpdate {
+    // Peer from which this message originates. Represented as a byte-encoded
+    // public key.
+    bytes peer = 1;
+
+    // PathKey is used to derive the blinded node id by tweaking the hop's
+    // static public key. The hop uses the corresponding blinded private key
+    // together with the sender's ephemeral key to perform ECDH and obtain the
+    // shared secret for decrypting the onion payload. Separately, for
+    // decrypting `encrypted_recipient_data`, the recipient performs ECDH
+    // between its static node private key and the path_key to derive the
+    // decryption key.
+    bytes path_key = 2;
+
+    // Serialized Sphinx onion packet (BOLT 4) containing the layered, per-hop
+    // encrypted payloads and routing instructions used to forward this message
+    // along its designated path.
+    bytes onion = 3;
+
+    // reply_path is the blinded path that should be used when replying to a
+    // received message.
+    BlindedPath reply_path = 4;
+
+    // encrypted_recipient_data is the encrypted data that contains the
+    // forwarding information for an onion message. It contains either
+    // next_node_id or short_channel_id for each non-final node. It MAY contain
+    // the path_id for the final node.
+    bytes encrypted_recipient_data = 5;
+
+    // Custom onion message tlv records. These are customized fields that are
+    // not defined by LND and cannot be extracted.
+    map<uint64, bytes> custom_records = 6;
+}
+
+message SendOnionMessageRequest {
+    // Peer to send the message to
+    bytes peer = 1;
+
+    // PathKey is used to derive the blinded node id by tweaking the hop's
+    // static public key. The hop uses the corresponding blinded private key
+    // together with the sender's ephemeral key to perform ECDH and obtain the
+    // shared secret for decrypting the onion payload. Separately, for
+    // decrypting `encrypted_recipient_data`, the recipient performs ECDH
+    // between its static node private key and the path_key to derive the
+    // decryption key.
+    bytes path_key = 2;
+
+    // Serialized Sphinx onion packet (BOLT 4) containing the layered, per-hop
+    // encrypted payloads and routing instructions used to forward this message
+    // along its designated path.
+    bytes onion = 3;
+}
+
+message SendOnionMessageResponse {
+    // The status of the onion message send operation.
     string status = 1;
 }
 
@@ -812,139 +853,6 @@ message FeeLimit {
         // The fee limit expressed as a percentage of the payment amount.
         int64 percent = 2;
     }
-}
-
-message SendRequest {
-    /*
-    The identity pubkey of the payment recipient. When using REST, this field
-    must be encoded as base64.
-    */
-    bytes dest = 1;
-
-    /*
-    The hex-encoded identity pubkey of the payment recipient. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string dest_string = 2 [deprecated = true];
-
-    /*
-    The amount to send expressed in satoshis.
-
-    The fields amt and amt_msat are mutually exclusive.
-    */
-    int64 amt = 3;
-
-    /*
-    The amount to send expressed in millisatoshis.
-
-    The fields amt and amt_msat are mutually exclusive.
-    */
-    int64 amt_msat = 12;
-
-    /*
-    The hash to use within the payment's HTLC. When using REST, this field
-    must be encoded as base64.
-    */
-    bytes payment_hash = 4;
-
-    /*
-    The hex-encoded hash to use within the payment's HTLC. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string payment_hash_string = 5 [deprecated = true];
-
-    /*
-    A bare-bones invoice for a payment within the Lightning Network. With the
-    details of the invoice, the sender has all the data necessary to send a
-    payment to the recipient.
-    */
-    string payment_request = 6;
-
-    /*
-    The CLTV delta from the current height that should be used to set the
-    timelock for the final hop.
-    */
-    int32 final_cltv_delta = 7;
-
-    /*
-    The maximum number of satoshis that will be paid as a fee of the payment.
-    This value can be represented either as a percentage of the amount being
-    sent, or as a fixed amount of the maximum fee the user is willing the pay to
-    send the payment. If not specified, lnd will use a default value of 100%
-    fees for small amounts (<=1k sat) or 5% fees for larger amounts.
-    */
-    FeeLimit fee_limit = 8;
-
-    /*
-    The channel id of the channel that must be taken to the first hop. If zero,
-    any channel may be used.
-    */
-    uint64 outgoing_chan_id = 9 [jstype = JS_STRING];
-
-    /*
-    The pubkey of the last hop of the route. If empty, any hop may be used.
-    */
-    bytes last_hop_pubkey = 13;
-
-    /*
-    An optional maximum total time lock for the route. This should not exceed
-    lnd's `--max-cltv-expiry` setting. If zero, then the value of
-    `--max-cltv-expiry` is enforced.
-    */
-    uint32 cltv_limit = 10;
-
-    /*
-    An optional field that can be used to pass an arbitrary set of TLV records
-    to a peer which understands the new records. This can be used to pass
-    application specific data during the payment attempt. Record types are
-    required to be in the custom range >= 65536. When using REST, the values
-    must be encoded as base64.
-    */
-    map<uint64, bytes> dest_custom_records = 11;
-
-    // If set, circular payments to self are permitted.
-    bool allow_self_payment = 14;
-
-    /*
-    Features assumed to be supported by the final node. All transitive feature
-    dependencies must also be set properly. For a given feature bit pair, either
-    optional or remote may be set, but not both. If this field is nil or empty,
-    the router will try to load destination features from the graph as a
-    fallback.
-    */
-    repeated FeatureBit dest_features = 15;
-
-    /*
-    The payment address of the generated invoice.  This is also called
-    payment secret in specifications (e.g. BOLT 11).
-    */
-    bytes payment_addr = 16;
-}
-
-message SendResponse {
-    string payment_error = 1;
-    bytes payment_preimage = 2;
-    Route payment_route = 3;
-    bytes payment_hash = 4;
-}
-
-message SendToRouteRequest {
-    /*
-    The payment hash to use for the HTLC. When using REST, this field must be
-    encoded as base64.
-    */
-    bytes payment_hash = 1;
-
-    /*
-    An optional hex-encoded payment hash to be used for the HTLC. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string payment_hash_string = 2 [deprecated = true];
-
-    reserved 3;
-
-    // Route that should be used to attempt to complete the payment.
-    Route route = 4;
 }
 
 message ChannelAcceptRequest {
@@ -1151,6 +1059,9 @@ message EstimateFeeRequest {
 
     // The strategy to use for selecting coins during fees estimation.
     CoinSelectionStrategy coin_selection_strategy = 5;
+
+    // A list of selected inputs for the transaction.
+    repeated OutPoint inputs = 6;
 }
 
 message EstimateFeeResponse {
@@ -1163,6 +1074,9 @@ message EstimateFeeResponse {
 
     // The fee rate in satoshi/vbyte.
     uint64 sat_per_vbyte = 3;
+
+    // A list of selected inputs for the transaction the estimate is for.
+    repeated OutPoint inputs = 4;
 }
 
 message SendManyRequest {
@@ -1391,6 +1305,11 @@ message HTLC {
 }
 
 enum CommitmentType {
+    // Allow multiple enum names to map to the same numeric value so the
+    // taproot channel types can expose short, canonical aliases without
+    // breaking on-wire compatibility with the historic names.
+    option allow_alias = true;
+
     /*
     Returned when the commitment type isn't known or unavailable.
     */
@@ -1427,8 +1346,25 @@ enum CommitmentType {
     SCRIPT_ENFORCED_LEASE = 4;
 
     /*
-    A channel that uses musig2 for the funding output, and the new tapscript
-    features where relevant.
+    The production taproot channel type that uses musig2 for the funding
+    output and the new tapscript features, with final scripts and feature
+    bits 80/81. This is the recommended taproot variant; new integrations
+    should select this enum value.
+    */
+    TAPROOT = 7;
+
+    /*
+    Deprecated alias for TAPROOT, preserved so existing clients that select
+    the production taproot channel type by its historic name continue to
+    compile and serialize against the same wire value.
+    */
+    SIMPLE_TAPROOT_FINAL = 7;
+
+    /*
+    A legacy taproot channel type that uses musig2 for the funding output and
+    the new tapscript features, but with development scripts and the staging
+    feature bits. Retained for compatibility with peers that have not upgraded
+    to TAPROOT; new integrations should prefer TAPROOT.
     */
     SIMPLE_TAPROOT = 5;
 
@@ -1911,6 +1847,7 @@ message Peer {
     repeated TimestampedError errors = 12;
 
     /*
+    This field is populated when the peer has at least one channel with us.
     The number of times we have recorded this peer going offline or coming
     online, recorded across restarts. Note that this value is decreased over
     time if the peer has not recently flapped, so that we can forgive peers
@@ -1919,6 +1856,7 @@ message Peer {
     int32 flap_count = 13;
 
     /*
+    This field is populated when the peer has at least one channel with us.
     The timestamp of the last flap we observed for this peer. If this value is
     zero, we have not observed any flaps for this peer.
     */
@@ -1968,6 +1906,13 @@ message PeerEvent {
 
 message GetInfoRequest {
 }
+enum GraphCacheStatus {
+    GRAPH_CACHE_STATUS_DISABLED = 0;
+    GRAPH_CACHE_STATUS_LOADING = 1;
+    GRAPH_CACHE_STATUS_LOADED = 2;
+    GRAPH_CACHE_STATUS_FAILED = 3;
+}
+
 message GetInfoResponse {
     // The version of the LND software that the node is running.
     string version = 14;
@@ -2042,9 +1987,19 @@ message GetInfoResponse {
 
     // Indicates whether final htlc resolutions are stored on disk.
     bool store_final_htlc_resolutions = 22;
+
+    // Whether the wallet is fully synced to the best chain. This indicates the
+    // wallet's internal sync state with the backing chain source.
+    bool wallet_synced = 23;
+
+    // The current status of the in-memory graph cache.
+    GraphCacheStatus graph_cache_status = 24;
 }
 
 message GetDebugInfoRequest {
+    // If set to true, the log file content will be included in the response.
+    // By default, only the config information is returned.
+    bool include_log = 1;
 }
 
 message GetDebugInfoResponse {
@@ -2072,13 +2027,6 @@ message Chain {
 
     // The network the node is on (eg regtest, testnet, mainnet)
     string network = 2;
-}
-
-message ConfirmationUpdate {
-    bytes block_sha = 1;
-    int32 block_height = 2;
-
-    uint32 num_confs_left = 3;
 }
 
 message ChannelOpenUpdate {
@@ -2847,6 +2795,25 @@ message PendingChannelsResponse {
         // very likely canceled the funding and the channel will never become
         // fully operational.
         int32 funding_expiry_blocks = 3;
+
+        // The number of blocks remaining until the channel status changes from
+        // pending to active. A value of 0 indicates that the channel is now
+        // active.
+        //
+        // "Active" here means both channel peers have the channel marked OPEN
+        // and can immediately start using it. For public channels, this does
+        // not imply a channel_announcement has been gossiped. It only becomes
+        // public on the network after 6 on‐chain confirmations.
+        // See BOLT07 "Routing Gossip":
+        // https://github.com/lightning/bolts/blob/master/07-routing-gossip.md
+        //
+        // ZeroConf channels bypass the pending state entirely: they are marked
+        // active immediately upon creation, so they never show up as "pending".
+        uint32 confirmations_until_active = 7;
+
+        // The confirmation height records the block height at which the funding
+        // transaction was first confirmed.
+        uint32 confirmation_height = 8;
     }
 
     message WaitingCloseChannel {
@@ -2868,6 +2835,24 @@ message PendingChannelsResponse {
         // The raw hex encoded bytes of the closing transaction. Included if
         // include_raw_tx in the request is true.
         string closing_tx_hex = 5;
+
+        /*
+        Remaining number of confirmations until the channel closure is
+        considered final and removed from waiting close. Channel closes
+        require multiple confirmations for reorg protection — the exact
+        number scales with channel capacity. A closing transaction that
+        gets reorganized out of the chain resets this counter. When the
+        closing transaction is not yet confirmed, this value equals the
+        total number of confirmations required.
+        */
+        uint32 blocks_til_close_confirmed = 6;
+
+        /*
+        The block height at which the closing transaction was first confirmed.
+        This will be zero if the closing transaction has not yet confirmed, or
+        if this information is not available for older channels.
+        */
+        uint32 close_height = 7;
     }
 
     message Commitments {
@@ -2972,6 +2957,10 @@ message PendingChannelsResponse {
 message ChannelEventSubscription {
 }
 
+message ChannelCommitUpdate {
+    Channel channel = 1;
+}
+
 message ChannelEventUpdate {
     oneof channel {
         Channel open_channel = 1;
@@ -2981,6 +2970,7 @@ message ChannelEventUpdate {
         PendingUpdate pending_open_channel = 6;
         ChannelPoint fully_resolved_channel = 7;
         ChannelPoint channel_funding_timeout = 8;
+        ChannelCommitUpdate updated_channel = 9;
     }
 
     enum UpdateType {
@@ -2991,6 +2981,7 @@ message ChannelEventUpdate {
         PENDING_OPEN_CHANNEL = 4;
         FULLY_RESOLVED_CHANNEL = 5;
         CHANNEL_FUNDING_TIMEOUT = 6;
+        CHANNEL_UPDATE = 7;
     }
 
     UpdateType type = 5;
@@ -3164,11 +3155,7 @@ message QueryRoutesRequest {
     */
     map<uint64, bytes> dest_custom_records = 13;
 
-    /*
-    The channel id of the channel that must be taken to the first hop. If zero,
-    any channel may be used.
-    */
-    uint64 outgoing_chan_id = 14 [jstype = JS_STRING];
+    reserved 14;
 
     /*
     The pubkey of the last hop of the route. If empty, any hop may be used.
@@ -3203,6 +3190,12 @@ message QueryRoutesRequest {
     only, to 1 to optimize for reliability only or a value inbetween for a mix.
     */
     double time_pref = 18;
+
+    /*
+    The channel ids of the channels allowed for the first hop. If empty, any
+    channel may be used.
+    */
+    repeated uint64 outgoing_chan_ids = 20;
 }
 
 message NodePair {
@@ -3423,6 +3416,10 @@ message NodeInfoRequest {
 
     // If true, will include all known channels associated with the node.
     bool include_channels = 2;
+
+    // If true, will include announcements' signatures into ChannelEdge.
+    // Depends on include_channels.
+    bool include_auth_proof = 3;
 }
 
 message NodeInfo {
@@ -3476,11 +3473,37 @@ message RoutingPolicy {
     uint64 max_htlc_msat = 6;
     uint32 last_update = 7;
 
-    // Custom channel update tlv records.
+    // Custom channel update tlv records. These are customized fields that are
+    // not defined by LND and cannot be extracted.
     map<uint64, bytes> custom_records = 8;
 
     int32 inbound_fee_base_msat = 9;
     int32 inbound_fee_rate_milli_msat = 10;
+}
+
+/*
+ChannelAuthProof is the authentication proof (the signature portion) for a
+channel. Using the four signatures contained in the struct, and some
+auxiliary knowledge (the funding script, node identities, and outpoint) nodes
+on the network are able to validate the authenticity and existence of a
+channel.
+*/
+message ChannelAuthProof {
+    // node_sig1 are the raw bytes of the first node signature encoded
+    // in DER format.
+    bytes node_sig1 = 1;
+
+    // bitcoin_sig1 are the raw bytes of the first bitcoin signature of the
+    // MultiSigKey key of the channel encoded in DER format.
+    bytes bitcoin_sig1 = 2;
+
+    // node_sig2 are the raw bytes of the second node signature encoded
+    // in DER format.
+    bytes node_sig2 = 3;
+
+    // bitcoin_sig2 are the raw bytes of the second bitcoin signature of the
+    // MultiSigKey key of the channel encoded in DER format.
+    bytes bitcoin_sig2 = 4;
 }
 
 /*
@@ -3511,6 +3534,13 @@ message ChannelEdge {
 
     // Custom channel announcement tlv records.
     map<uint64, bytes> custom_records = 9;
+
+    // Authentication proof for this channel. This proof contains a set of
+    // signatures binding four identities, which attests to the legitimacy of
+    // the advertised channel. This only is available for advertised channels.
+    // This field is not filled by default. Pass include_auth_proof flag to
+    // DescribeGraph, GetNodeInfo or GetChanInfo to get this data.
+    ChannelAuthProof auth_proof = 10;
 }
 
 message ChannelGraphRequest {
@@ -3520,6 +3550,9 @@ message ChannelGraphRequest {
     channels, and public channels that are not yet announced to the network.
     */
     bool include_unannounced = 1;
+
+    // If true, will include announcements' signatures into ChannelEdge.
+    bool include_auth_proof = 2;
 }
 
 // Returns a new instance of the directed channel graph.
@@ -3571,6 +3604,9 @@ message ChanInfoRequest {
     // The channel point of the channel in format funding_txid:output_index. If
     // chan_id is specified, this field is ignored.
     string chan_point = 2;
+
+    // If true, will include announcements' signatures into ChannelEdge.
+    bool include_auth_proof = 3;
 }
 
 message NetworkInfoRequest {
@@ -4004,6 +4040,12 @@ message BlindedPathConfig {
     blinded paths.
     */
     repeated bytes node_omission_list = 4;
+
+    /*
+    The chained channels list specified via channel id (separated by commas),
+    starting from a channel owned by the receiver node.
+    */
+    repeated uint64 incoming_channel_list = 5;
 }
 
 enum InvoiceHTLCState {
@@ -4183,6 +4225,16 @@ message InvoiceSubscription {
     they weren't connected to the streaming RPC.
     */
     uint64 settle_index = 2;
+}
+
+message DelCanceledInvoiceReq {
+    // Invoice payment hash to delete.
+    string invoice_hash = 1;
+}
+
+message DelCanceledInvoiceResp {
+    // The status of the delete operation.
+    string status = 1;
 }
 
 enum PaymentFailureReason {
@@ -4374,6 +4426,10 @@ message ListPaymentsRequest {
     // If set, returns all payments with a creation date less than or equal to
     // it. Measured in seconds since the unix epoch.
     uint64 creation_date_end = 7;
+
+    // If set, omit hop-level route data for HTLC attempts to reduce query
+    // cost and response size.
+    bool omit_hops = 8;
 }
 
 message ListPaymentsResponse {
@@ -4667,6 +4723,14 @@ message ForwardingHistoryRequest {
     // Informs the server if the peer alias should be looked up for each
     // forwarding event.
     bool peer_alias_lookup = 5;
+
+    // List of incoming channel ids to filter htlcs received from a
+    // particular channel
+    repeated uint64 incoming_chan_ids = 6;
+
+    // List of outgoing channel ids to filter htlcs being forwarded to a
+    // particular channel
+    repeated uint64 outgoing_chan_ids = 7;
 }
 message ForwardingEvent {
     // Timestamp is the time (unix epoch offset) that this circuit was
@@ -5051,9 +5115,37 @@ message Op {
 }
 
 message CheckMacPermRequest {
+    // The macaroon to check permissions for, serialized in binary format. For
+    // a macaroon to be valid, it must have been issued by lnd, must succeed all
+    // caveat conditions, and must contain all of the permissions specified in
+    // the permissions field.
     bytes macaroon = 1;
+
+    // The list of permissions the macaroon should be checked against. Only if
+    // the macaroon contains all of these permissions, it is considered valid.
+    // If the list of permissions given is empty, then the macaroon is
+    // considered valid only based on issuance authority and caveat validity.
+    // An empty list of permissions is therefore equivalent to saying "skip
+    // checking permissions" (unless check_default_perms_from_full_method is
+    // specified).
     repeated MacaroonPermission permissions = 2;
+
+    // The RPC method to check the macaroon against. This is only used if there
+    // are custom `uri:<rpcpackage>.<ServiceName>/<MethodName>` permissions in
+    // the permission list above. To check a macaroon against the list of
+    // permissions of a certain RPC method, query the `ListPermissions` RPC
+    // first, extract the permissions for the method, and then pass them in the
+    // `permissions` field above.
     string fullMethod = 3;
+
+    // If this field is set to true, then the permissions list above MUST be
+    // empty. The default permissions for the provided fullMethod will be used
+    // to check the macaroon. This is equivalent to looking up the permissions
+    // for a method in the `ListPermissions` RPC and then calling this RPC with
+    // the permission list returned from that call. Without this flag, the list
+    // of permissions must be non-empty for the check to actually perform a
+    // permission check.
+    bool check_default_perms_from_full_method = 4;
 }
 
 message CheckMacPermResponse {

--- a/vendor/routerrpc/router.proto
+++ b/vendor/routerrpc/router.proto
@@ -27,7 +27,7 @@ option go_package = "github.com/lightningnetwork/lnd/lnrpc/routerrpc";
 // Router is a service that offers advanced interaction with the router
 // subsystem of the daemon.
 service Router {
-    /*
+    /* lncli: `sendpayment`
     SendPaymentV2 attempts to route a payment described by the passed
     PaymentRequest to the final destination. The call returns a stream of
     payment updates. When using this RPC, make sure to set a fee limit, as the
@@ -53,24 +53,13 @@ service Router {
     */
     rpc TrackPayments (TrackPaymentsRequest) returns (stream lnrpc.Payment);
 
-    /*
+    /* lncli: `estimateroutefee`
     EstimateRouteFee allows callers to obtain a lower bound w.r.t how much it
     may cost to send an HTLC to the target end destination.
     */
     rpc EstimateRouteFee (RouteFeeRequest) returns (RouteFeeResponse);
 
-    /*
-    Deprecated, use SendToRouteV2. SendToRoute attempts to make a payment via
-    the specified route. This method differs from SendPayment in that it
-    allows users to specify a full route manually. This can be used for
-    things like rebalancing, and atomic swaps. It differs from the newer
-    SendToRouteV2 in that it doesn't return the full HTLC information.
-    */
-    rpc SendToRoute (SendToRouteRequest) returns (SendToRouteResponse) {
-        option deprecated = true;
-    }
-
-    /*
+    /* lncli: `sendtoroute`
     SendToRouteV2 attempts to make a payment via the specified route. This
     method differs from SendPayment in that it allows users to specify a full
     route manually. This can be used for things like rebalancing, and atomic
@@ -141,23 +130,6 @@ service Router {
     rpc SubscribeHtlcEvents (SubscribeHtlcEventsRequest)
         returns (stream HtlcEvent);
 
-    /*
-    Deprecated, use SendPaymentV2. SendPayment attempts to route a payment
-    described by the passed PaymentRequest to the final destination. The call
-    returns a stream of payment status updates.
-    */
-    rpc SendPayment (SendPaymentRequest) returns (stream PaymentStatus) {
-        option deprecated = true;
-    }
-
-    /*
-    Deprecated, use TrackPaymentV2. TrackPayment returns an update stream for
-    the payment identified by the payment hash.
-    */
-    rpc TrackPayment (TrackPaymentRequest) returns (stream PaymentStatus) {
-        option deprecated = true;
-    }
-
     /**
     HtlcInterceptor dispatches a bi-directional streaming RPC in which
     Forwarded HTLC requests are sent to the client and the client responds with
@@ -195,6 +167,25 @@ service Router {
     */
     rpc XDeleteLocalChanAliases (DeleteAliasesRequest)
         returns (DeleteAliasesResponse);
+
+    /*
+    XFindBaseLocalChanAlias is an experimental API that looks up the base scid
+    for a local chan alias that was registered during the current runtime.
+    */
+    rpc XFindBaseLocalChanAlias (FindBaseAliasRequest)
+        returns (FindBaseAliasResponse);
+
+    /* lncli: `deletefwdhistory`
+    DeleteForwardingHistory allows the caller to delete forwarding history
+    events with a timestamp at or before a specified time. This is useful
+    for implementing data retention policies for privacy purposes. The call
+    deletes events in batches and returns statistics including the total number
+    of events deleted and the aggregate fees earned from those events. The
+    deletion is performed in a transaction-safe manner with configurable batch
+    sizes to avoid holding large database locks.
+    */
+    rpc DeleteForwardingHistory (DeleteForwardingHistoryRequest)
+        returns (DeleteForwardingHistoryResponse);
 }
 
 message SendPaymentRequest {
@@ -245,12 +236,7 @@ message SendPaymentRequest {
     */
     int64 fee_limit_sat = 7;
 
-    /*
-    Deprecated, use outgoing_chan_ids. The channel id of the channel that must
-    be taken to the first hop. If zero, any channel may be used (unless
-    outgoing_chan_ids are set).
-    */
-    uint64 outgoing_chan_id = 8 [jstype = JS_STRING, deprecated = true];
+    reserved 8;
 
     /*
     An optional maximum total time lock for the route. This should not
@@ -470,14 +456,6 @@ message SendToRouteRequest {
     base64.
     */
     map<uint64, bytes> first_hop_custom_records = 4;
-}
-
-message SendToRouteResponse {
-    // The preimage obtained by making the payment.
-    bytes preimage = 1;
-
-    // The failure message in case the payment failed.
-    lnrpc.Failure failure = 2;
 }
 
 message ResetMissionControlRequest {
@@ -904,62 +882,11 @@ enum FailureDetail {
     INVALID_KEYSEND = 20;
     MPP_IN_PROGRESS = 21;
     CIRCULAR_ROUTE = 22;
-}
-
-enum PaymentState {
-    /*
-    Payment is still in flight.
-    */
-    IN_FLIGHT = 0;
-
-    /*
-    Payment completed successfully.
-    */
-    SUCCEEDED = 1;
-
-    /*
-    There are more routes to try, but the payment timeout was exceeded.
-    */
-    FAILED_TIMEOUT = 2;
-
-    /*
-    All possible routes were tried and failed permanently. Or were no
-    routes to the destination at all.
-    */
-    FAILED_NO_ROUTE = 3;
-
-    /*
-    A non-recoverable error has occurred.
-    */
-    FAILED_ERROR = 4;
-
-    /*
-    Payment details incorrect (unknown hash, invalid amt or
-    invalid final cltv delta)
-    */
-    FAILED_INCORRECT_PAYMENT_DETAILS = 5;
-
-    /*
-    Insufficient local balance.
-    */
-    FAILED_INSUFFICIENT_BALANCE = 6;
-}
-
-message PaymentStatus {
-    // Current state the payment is in.
-    PaymentState state = 1;
-
-    /*
-    The pre-image of the payment when state is SUCCEEDED.
-    */
-    bytes preimage = 2;
-
-    reserved 3;
-
-    /*
-    The HTLCs made in attempt to settle the payment [EXPERIMENTAL].
-    */
-    repeated lnrpc.HTLCAttempt htlcs = 4;
+    INVOICE_ALREADY_SETTLED = 23;
+    HTLC_INVOICE_TYPE_MISMATCH = 24;
+    AMP_ERROR = 25;
+    AMP_RECONSTRUCTION = 26;
+    EXTERNAL_VALIDATION_FAILED = 27;
 }
 
 message CircuitKey {
@@ -974,6 +901,10 @@ message ForwardHtlcInterceptRequest {
     /*
     The key of this forwarded htlc. It defines the incoming channel id and
     the index in this channel.
+
+    Interceptor clients should handle requests for the same circuit key
+    idempotently. Requests may be replayed after reconnect, and an htlc that was
+    previously offered off-chain may be offered again after it moves on-chain.
     */
     CircuitKey incoming_circuit_key = 1;
 
@@ -1008,7 +939,8 @@ message ForwardHtlcInterceptRequest {
     bytes onion_blob = 9;
 
     // The block height at which this htlc will be auto-failed to prevent the
-    // channel from force-closing.
+    // channel from force-closing. For on-chain htlcs, this field is the
+    // settlement deadline instead and no automatic fail-back is attempted.
     int32 auto_fail_height = 10;
 
     // The custom records of the peer's incoming p2p wire message.
@@ -1023,6 +955,14 @@ forward. The caller can choose either to:
                     field modifications.
 - `Reject`: Fail the htlc backwards.
 - `Settle`: Settle this htlc with a given preimage.
+
+Once the incoming channel has force-closed and the HTLC is being resolved
+on-chain (see auto_fail_height), only `Settle` has any effect. The HTLC can no
+longer be resumed or failed back off-chain, so `Resume`, `ResumeModified`, and
+`Fail` return a stream-terminating error. The HTLC stays held until it is
+settled with a preimage, the on-chain resolver completes, or it expires
+on-chain. Clients should reconnect to receive any held HTLCs that remain
+unresolved.
 */
 message ForwardHtlcInterceptResponse {
     /**
@@ -1116,4 +1056,46 @@ message DeleteAliasesRequest {
 
 message DeleteAliasesResponse {
     repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message FindBaseAliasRequest {
+    // The alias we want to look up the base scid for.
+    uint64 alias = 1;
+}
+
+message FindBaseAliasResponse {
+    // The base scid that resulted from the base scid look up.
+    uint64 base = 1;
+}
+
+message DeleteForwardingHistoryRequest {
+    // Specify the cutoff time for deletion using one of the following options.
+    // Events with a timestamp at or before the cutoff are deleted.
+    oneof time_spec {
+        // Absolute Unix timestamp (seconds). Events at or before this time
+        // are deleted.
+        uint64 delete_before_time = 1;
+
+        // Relative duration string indicating how far back to delete, e.g.
+        // "-30d" deletes events at or before 30 days ago.
+        // Standard Go: "-24h", "-1.5h"
+        // Custom units: "-1d", "-1w", "-1M", "-1y"
+        // Supported: ns, us/µs, ms, s, m, h, d (days), w (weeks),
+        // M (months=30.44d), y (years=365.25d).
+        // Use negative values to specify time in the past.
+        string delete_before_duration = 2;
+    }
+}
+
+message DeleteForwardingHistoryResponse {
+    // Number of forwarding events deleted.
+    uint64 events_deleted = 1;
+
+    // Total fees earned from deleted events (in millisatoshis).
+    // This is the sum of (amt_in - amt_out) for all deleted events, which
+    // can be used for accounting purposes.
+    int64 total_fee_msat = 2;
+
+    // Status message.
+    string status = 3;
 }

--- a/vendor/signrpc/signer.proto
+++ b/vendor/signrpc/signer.proto
@@ -107,6 +107,34 @@ service Signer {
         returns (MuSig2RegisterNoncesResponse);
 
     /*
+    MuSig2RegisterCombinedNonce (experimental!) registers a pre-aggregated
+    combined nonce for a signing session. This is an alternative to
+    MuSig2RegisterNonces and is used when a coordinator has already aggregated
+    all individual nonces and wants to distribute the combined nonce to
+    participants.
+
+    NOTE: This method is mutually exclusive with MuSig2RegisterNonces for the
+    same session. The MuSig2 BIP is not final yet and therefore this API must
+    be considered to be HIGHLY EXPERIMENTAL and subject to change in upcoming
+    releases. Backward compatibility is not guaranteed!
+    */
+    rpc MuSig2RegisterCombinedNonce (MuSig2RegisterCombinedNonceRequest)
+        returns (MuSig2RegisterCombinedNonceResponse);
+
+    /*
+    MuSig2GetCombinedNonce (experimental!) retrieves the combined nonce for a
+    signing session. This will be available after either all individual nonces
+    have been registered via MuSig2RegisterNonces, or a combined nonce has been
+    registered via MuSig2RegisterCombinedNonce.
+
+    NOTE: The MuSig2 BIP is not final yet and therefore this API must be
+    considered to be HIGHLY EXPERIMENTAL and subject to change in upcoming
+    releases. Backward compatibility is not guaranteed!
+    */
+    rpc MuSig2GetCombinedNonce (MuSig2GetCombinedNonceRequest)
+        returns (MuSig2GetCombinedNonceResponse);
+
+    /*
     MuSig2Sign (experimental!) creates a partial signature using the local
     signing key that was specified when the session was created. This can only
     be called when all public nonces of all participants are known and have been
@@ -643,6 +671,38 @@ message MuSig2RegisterNoncesResponse {
     now.
     */
     bool have_all_nonces = 1;
+}
+
+message MuSig2RegisterCombinedNonceRequest {
+    /*
+    The unique ID of the signing session the combined nonce should be registered
+    with.
+    */
+    bytes session_id = 1;
+
+    /*
+    The 66-byte combined public nonce that was aggregated externally. This is a
+    concatenation of two 33-byte compressed public keys (R1 || R2).
+    */
+    bytes combined_public_nonce = 2;
+}
+
+message MuSig2RegisterCombinedNonceResponse {
+}
+
+message MuSig2GetCombinedNonceRequest {
+    /*
+    The unique ID of the signing session to get the combined nonce for.
+    */
+    bytes session_id = 1;
+}
+
+message MuSig2GetCombinedNonceResponse {
+    /*
+    The 66-byte combined public nonce. This is a concatenation of two 33-byte
+    compressed public keys (R1 || R2).
+    */
+    bytes combined_public_nonce = 1;
 }
 
 message MuSig2SignRequest {

--- a/vendor/walletrpc/walletkit.proto
+++ b/vendor/walletrpc/walletkit.proto
@@ -328,7 +328,7 @@ service WalletKit {
     */
     rpc FundPsbt (FundPsbtRequest) returns (FundPsbtResponse);
 
-    /*
+    /* lncli: `wallet psbt sign`
     SignPsbt expects a partial transaction with all inputs and outputs fully
     declared and tries to sign all unsigned inputs that have all required fields
     (UTXO information, BIP32 derivation information, witness or sig scripts)
@@ -1098,6 +1098,56 @@ enum WitnessType {
     counterparty's who broadcasts a revoked taproot commitment transaction.
     */
     TAPROOT_COMMITMENT_REVOKE = 35;
+
+    /*
+    A witness type that allows us to spend our settled local commitment after a
+    CSV delay when we force close a production taproot channel.
+    */
+    TAPROOT_LOCAL_COMMIT_SPEND_FINAL = 36;
+
+    /*
+    A witness type that allows us to spend our settled local commitment after
+    a CSV delay when the remote party has force closed a production taproot
+    channel.
+    */
+    TAPROOT_REMOTE_COMMIT_SPEND_FINAL = 37;
+
+    /*
+    A witness that allows us to timeout an HTLC we offered to the remote party
+    on our production taproot commitment transaction. We use this when we need
+    to go on chain to time out an HTLC.
+    */
+    TAPROOT_HTLC_OFFERED_TIMEOUT_SECOND_LEVEL_FINAL = 38;
+
+    /*
+    A witness type that allows us to sweep an HTLC we accepted on our
+    production taproot commitment transaction after we go to the second level
+    on chain.
+    */
+    TAPROOT_HTLC_ACCEPTED_SUCCESS_SECOND_LEVEL_FINAL = 39;
+
+    /*
+    A witness that allows us to sweep an HTLC we offered to the remote party
+    that lies on the production taproot commitment transaction for the remote
+    party. We can spend this output after the absolute CLTV timeout of the
+    HTLC as passed.
+    */
+    TAPROOT_HTLC_OFFERED_REMOTE_TIMEOUT_FINAL = 40;
+
+    /*
+    A witness that allows us to sweep an HTLC that was offered to us by the
+    remote party for a production taproot channel. We use this witness in the
+    case that the remote party goes to chain, and we know the pre-image to the
+    HTLC. We can sweep this without any additional timeout.
+    */
+    TAPROOT_HTLC_ACCEPTED_REMOTE_SUCCESS_FINAL = 41;
+
+    /*
+    A witness type that allows us to sweep the settled output of a malicious
+    counterparty's who broadcasts a revoked production taproot commitment
+    transaction.
+    */
+    TAPROOT_COMMITMENT_REVOKE_FINAL = 42;
 }
 
 message PendingSweep {


### PR DESCRIPTION
## Summary
- vendor LND v0.21.1-beta gRPC protos for the LND RPC surface
- expose ChainKit and ChainNotifier clients behind a new chainrpc feature
- document chain confirmation APIs and refresh dependency minimums

