### PR TITLE
chore: release voltage-tonic-lnd 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "voltage-tonic-lnd"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "hex",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "voltage-tonic-lnd"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.75.0"
 description = "An async library implementing LND RPC via tonic and prost. Forked from https://github.com/Kixunil/tonic_lnd"


### PR DESCRIPTION
## Summary
- bump voltage-tonic-lnd crate version to 0.5.0 after the LND v0.21.1-beta chainrpc update
- update Cargo.lock package metadata to match

## Validation
- not run per request